### PR TITLE
Change Office to Internet in generated desktop file

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -475,7 +475,7 @@ namespace WalletWasabi.Packager
 						$"Icon={ExecutableName}\n" +
 						$"Terminal=false\n" +
 						$"Exec={ExecutableName}\n" +
-						$"Categories=Office;Finance;\n" +
+						$"Categories=Internet;Finance;\n" +
 						$"Keywords=bitcoin;wallet;crypto;blockchain;wasabi;privacy;anon;awesome;qwe;asd;\n";
 
 					File.WriteAllText(desktopFilePath, desktopFileContent, Encoding.ASCII);


### PR DESCRIPTION
While building Wasabi for Debian, the generated desktop file is placing the Wasabi application to the Office category. Change it to Internet to make it more clear on the purpose of the software.

Fixes #6031.